### PR TITLE
Validate google font api requests and save css

### DIFF
--- a/core/includes/classes/class-responsive-local-fonts.php
+++ b/core/includes/classes/class-responsive-local-fonts.php
@@ -36,6 +36,8 @@ if ( ! class_exists( 'Responsive_Local_Fonts' ) ) :
 			if ( empty( $google_css_url ) ) {
 				return false;
 			}
+			// Ensure the URL is in a request-safe format (avoid HTML entities like &amp;)
+			$google_css_url = html_entity_decode( $google_css_url, ENT_QUOTES );
 			list( $base_dir, $base_url ) = self::get_uploads();
 			$hash      = md5( $google_css_url );
 			$targetDir = trailingslashit( $base_dir . $hash );
@@ -51,6 +53,11 @@ if ( ! class_exists( 'Responsive_Local_Fonts' ) ) :
 
 			$response = wp_remote_get( $google_css_url, array( 'timeout' => 15 ) );
 			if ( is_wp_error( $response ) ) {
+				return false;
+			}
+			// If Google returns a 400, skip caching and bail out.
+			$status_code = (int) wp_remote_retrieve_response_code( $response );
+			if ( 400 === $status_code ) {
 				return false;
 			}
 			$css = wp_remote_retrieve_body( $response );

--- a/core/includes/customizer/controls/typography/webfonts.php
+++ b/core/includes/customizer/controls/typography/webfonts.php
@@ -277,17 +277,29 @@ function responsive_render_google_fonts_url( $fonts ) {
 		return;
 	}
 
-	// Main URL.
+	// Main URL and query assembly.
 	$url = 'https://fonts.googleapis.com/css?family=';
+	$query_parts = array();
 	foreach ( $fonts as $font ) {
 		// Clean font name: remove quotes and fallback (after comma)
 		$clean_font = trim( preg_replace( "/['\"]/", '', explode(',', $font)[0] ) );
 		$google_fonts = responsive_get_google_fonts();
-		if ( isset($google_fonts) && array_key_exists( $clean_font, $google_fonts ) ) {
+		if ( isset( $google_fonts ) && array_key_exists( $clean_font, $google_fonts ) ) {
 			$isGoogleFont = true; // Change the value to true if any one font is a Google Font.
+			$fragment = responsive_enqueue_google_font_url( $clean_font );
+			if ( ! empty( $fragment ) ) {
+				$query_parts[] = $fragment;
+			}
 		}
-		$url .= responsive_enqueue_google_font( $clean_font ) . '%7C';
 	}
+
+	// If we have no valid Google font fragments, avoid producing a malformed URL.
+	if ( empty( $query_parts ) ) {
+		wp_dequeue_style( 'responsive-google-font-css' );
+		return;
+	}
+
+	$url .= implode( '%7C', $query_parts );
 
 	// Subset.
 	$get_subsets = get_theme_mod( 'responsive_google_font_subsets', array( 'latin' ) );


### PR DESCRIPTION
## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code

### Description

This PR addresses two issues related to Google Fonts API requests and local caching:

1.  **Prevents local CSS caching for invalid Google Fonts API responses:**
    *   The `Responsive_Local_Fonts::cache_and_get_url` method now decodes HTML entities in the Google CSS URL before making the request.
    *   It also checks the HTTP status code of the Google Fonts API response. If a 400 status code is returned, the CSS is not saved locally, preventing the caching of invalid or malformed responses.

2.  **Fixes malformed Google Fonts API URLs:**
    *   The `responsive_render_google_fonts_url` function has been refactored to correctly construct the Google Fonts URL.
    *   It now uses `responsive_enqueue_google_font_url` for each font family and only appends valid font fragments to the URL.
    *   Crucially, if no valid Google font families are found, the function now bails out and dequeues the Google Font style, preventing malformed URLs like `https://fonts.googleapis.com/css?family&subset=latin...` from being generated and requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-76a67bc9-978b-4498-8e6c-5b01f1ddf6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76a67bc9-978b-4498-8e6c-5b01f1ddf6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

